### PR TITLE
Fix $remindme crashing when an invalid time is passed as the first argument

### DIFF
--- a/modules/utility/commands/remindme.js
+++ b/modules/utility/commands/remindme.js
@@ -20,9 +20,10 @@ module.exports = {
         var connection = client.scripts.getSQL(false);
 
         let params = message.content.split(" ").slice(1);
-        let time = parseInt(client.time.fromString(params[0]).ms)
-        if (!time) return message.reply("No time args received.")
-        if (time < 60000 * 5 || isNaN(time)) return message.reply("Reminders must be set more than 5 minutes in the Future.")
+        let time = parseInt(client.time.fromString(params[0]));
+        if (!time) return message.reply("Expected first argument to be a time; for example, 1m, 2h, 3d.");
+        let time_ms = time.ms;
+        if (time_ms < 60000 * 5 || isNaN(time_ms)) return message.reply("Reminders must be set more than 5 minutes in the Future.")
         var reminder = args.join(" ").slice(args[0].length)
         if (!reminder) reminder = "No reason."
         if (reminder.length > 512 || reminder.length < 2) return message.reply("Reminders must be between 2 and 512 characters in length.")

--- a/modules/utility/commands/remindme.js
+++ b/modules/utility/commands/remindme.js
@@ -20,9 +20,9 @@ module.exports = {
         var connection = client.scripts.getSQL(false);
 
         let params = message.content.split(" ").slice(1);
-        let time = parseInt(client.time.fromString(params[0]));
+        let time = client.time.fromString(params[0]);
         if (!time) return message.reply("Expected first argument to be a time; for example, 1m, 2h, 3d.");
-        let time_ms = time.ms;
+        let time_ms = parseInt(time.ms);
         if (time_ms < 60000 * 5 || isNaN(time_ms)) return message.reply("Reminders must be set more than 5 minutes in the Future.")
         var reminder = args.join(" ").slice(args[0].length)
         if (!reminder) reminder = "No reason."
@@ -55,3 +55,4 @@ module.exports = {
         })
     }
 }
+


### PR DESCRIPTION
A common sight in #bot-commands is a stacktrace like this: 
![image](https://user-images.githubusercontent.com/57954188/208003240-f54b50e8-b8a1-4864-a094-ca5069bd6710.png)
It does it's job: showing what went wrong and where so it can be fixed, but this is unhelpful for people who just want to make a simple reminder, especially when the time can be so easy to forget. 

The problem is caused because we try to access the `ms` property of the parsed time before checking that it has been successfully parsed (hence the `Cannot read property 'ms' of undefined` error); so, by checking the time object first, this issue is avoided.

Also the error message is hopefully more helpful (albeit grammatically dubious). 